### PR TITLE
fix: definition of query missed on location

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ export interface Location<S = LocationState> {
     state: S;
     hash: Hash;
     key?: LocationKey;
+    query?: {[key: string]: any};
 }
 
 export interface LocationDescriptorObject<S = LocationState> {


### PR DESCRIPTION
`Location` 上缺了 `query` 的定义